### PR TITLE
Make cover file optional

### DIFF
--- a/_plugins/thumbnail_generator.rb
+++ b/_plugins/thumbnail_generator.rb
@@ -73,7 +73,8 @@ module Jekyll
     def generate_cover_thumbnail(site, doc, asset_dir)
         cover = doc.data['cover'] || Default_cover
         cover_file = "#{asset_dir}/#{cover}"
-
+        return [] if ! File.exists? cover_file
+      
         image = Image.read(cover_file)[0]
         thumbnail_file = "#{asset_dir}/#{Thumbnails_dir}/#{cover}"
 


### PR DESCRIPTION
Instead of breaking here - make the cover file optional.

This fixes the error seen below when a cover file isn't present:

```
/srv/jekyll/_plugins/thumbnail_generator.rb:78:in `read': unable to open image 'assets/posts/foam-core-drawer-dividers/cover.jpg': No such file or directory @ error/blob.c/OpenBlob/3496 (Magick::ImageMagickError)
```
