### PR TITLE
Allow the asset dir to be overridden

### DIFF
--- a/_plugins/thumbnail_generator.rb
+++ b/_plugins/thumbnail_generator.rb
@@ -26,7 +26,8 @@ module Jekyll
         collections.each do |collection|
             collection_asset_base = "#{Asset_base}/#{collection.label}"
             collection.docs.each do |doc|
-                asset_dir = "#{collection_asset_base}/#{doc.data['slug']}";
+                asset_dir = doc.data["asset_dir"] || "#{collection_asset_base}/#{doc.data['slug']}";
+              
                 if not File.exists? asset_dir
                     raise "Asset directory '#{asset_dir}' not found."
                 end


### PR DESCRIPTION
With this change, the front matter for a page can specify an alternate asset dir. Useful on legacy sites with plenty fo images in another folder structure.